### PR TITLE
Support adding subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/
+.idea
+.gradle
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,3 @@ dependencies {
     testCompile 'org.assertj:assertj-core:3.4.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
-sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
-}

--- a/build.gradle
+++ b/build.gradle
@@ -34,5 +34,4 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttp_version}"
     testCompile 'org.assertj:assertj-core:3.4.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.3'
+    ext.kotlin_version = '1.0.6'
     ext.okhttp_version = '3.4.0'
 
     repositories {
@@ -34,4 +34,8 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile "com.squareup.okhttp3:mockwebserver:${okhttp_version}"
     testCompile 'org.assertj:assertj-core:3.4.1'
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+}
+sourceSets {
+    main.java.srcDirs += 'src/main/kotlin'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,4 +16,4 @@ include 'api'
 include 'services:webservice'
 */
 
-rootProject.name = 'java-ipfs-api'
+rootProject.name = 'ipfs-api-kotlin'

--- a/src/test/kotlin/io/ipfs/kotlin/TestAdd.kt
+++ b/src/test/kotlin/io/ipfs/kotlin/TestAdd.kt
@@ -58,15 +58,14 @@ class TestAdd() :BaseIPFSWebserverTest() {
         val dttf2 = File.createTempFile("dirtemptestfile2", null, path.toFile())
         dttf2.writeText("Contents of temptestdir/dirtemptestfile2")
 
-        val addString = ipfs.add.file(path.toFile(),path.fileName.toString())
+        val result = ipfs.add.directory(path.toFile(),path.fileName.toString())
 
         // assert
-        assertThat(addString.Hash).isEqualTo("hashprobe")
-        assertThat(addString.Name).isEqualTo("nameprobe")
+        assertThat(result.first().Hash).isEqualTo("hashprobe")
+        assertThat(result.first().Name).isEqualTo("nameprobe")
 
         val executedRequest = server.takeRequest()
         val body = executedRequest.body.readUtf8()
-        System.out.println(body)
         assertThat(executedRequest.path).startsWith("/add")
         assertThat(body).containsPattern(""".*temptestdir.*""")
     }


### PR DESCRIPTION
Added recursive subdirectory support, and a new method to add directories which returns a hash of all of the files added.  This was done to avoid breaking the existing addFile API which returns a single hash, and to allow the caller to add multiple files and get the hashes for each sub-file. I took care to make it compatible with the convention in java-ipfs-api (return the hash of the enclosing folder by default).

Also upgraded Kotlin and changed the Gradle configuration to make it work with Android Studio.
