### PR TITLE
Add Get cat methods for ByteArray and InputStream

### DIFF
--- a/src/main/kotlin/io/ipfs/kotlin/commands/Get.kt
+++ b/src/main/kotlin/io/ipfs/kotlin/commands/Get.kt
@@ -2,9 +2,34 @@ package io.ipfs.kotlin.commands
 
 import io.ipfs.kotlin.IPFSConnection
 import okhttp3.ResponseBody
+import java.io.InputStream
 
 class Get(val ipfs: IPFSConnection) {
 
+    /**
+     * Cat IPFS content and return it as string.
+     *
+     * @param hash The hash of the content in base58.
+     */
     fun cat(hash: String): String = ipfs.callCmd("cat/$hash").use(ResponseBody::string)
+
+    /**
+     * Cat IPFS content and return it as ByteArray.
+     *
+     * @param hash The hash of the content in base58.
+     */
+    fun catBytes(hash: String): ByteArray = ipfs.callCmd("cat/$hash").use(ResponseBody::bytes)
+
+    /**
+     * Cat IPFS content and process it using InputStream.
+     *
+     * @param hash The hash of the content in base58.
+     * @param handler Callback which handle processing the input stream. When the callback return the stream and the request body will be closed.
+     */
+    fun catStream(hash: String, handler: (stream: InputStream) -> Unit): Unit =
+            ipfs.callCmd("cat/$hash").use { body ->
+                val inputStream = body.byteStream()
+                inputStream.use(handler)
+            }
 
 }


### PR DESCRIPTION
When getting a binary file it's important to be able to access the data as either ByteArray for small content and InputStream for large content.