### PR TITLE
change get api deal with the 500 code

### DIFF
--- a/src/main/kotlin/io/ipfs/kotlin/commands/Get.kt
+++ b/src/main/kotlin/io/ipfs/kotlin/commands/Get.kt
@@ -1,6 +1,8 @@
 package io.ipfs.kotlin.commands
 
-import io.ipfs.kotlin.IPFSConnection
+import com.le.ipfsapi.IPFSConnection
+import okhttp3.Request
+import okhttp3.Response
 import okhttp3.ResponseBody
 import java.io.InputStream
 
@@ -11,14 +13,28 @@ class Get(val ipfs: IPFSConnection) {
      *
      * @param hash The hash of the content in base58.
      */
-    fun cat(hash: String): String = ipfs.callCmd("cat/$hash").use(ResponseBody::string)
+    fun cat(hash: String): String? {
+        val response = catApi(hash)
+        return if (response.isSuccessful && null != response.body()) {
+            response.body()!!.use(ResponseBody::string)
+        } else {
+            null
+        }
+    }
 
     /**
      * Cat IPFS content and return it as ByteArray.
      *
      * @param hash The hash of the content in base58.
      */
-    fun catBytes(hash: String): ByteArray = ipfs.callCmd("cat/$hash").use(ResponseBody::bytes)
+    fun catBytes(hash: String): ByteArray? {
+        val response = catApi(hash)
+        return if (response.isSuccessful && null != response.body()) {
+            response.body()!!.use { it.bytes() }
+        } else {
+            null
+        }
+    }
 
     /**
      * Cat IPFS content and process it using InputStream.
@@ -26,10 +42,29 @@ class Get(val ipfs: IPFSConnection) {
      * @param hash The hash of the content in base58.
      * @param handler Callback which handle processing the input stream. When the callback return the stream and the request body will be closed.
      */
-    fun catStream(hash: String, handler: (stream: InputStream) -> Unit): Unit =
-            ipfs.callCmd("cat/$hash").use { body ->
-                val inputStream = body.byteStream()
-                inputStream.use(handler)
-            }
+    fun catStream(hash: String, handler: (stream: InputStream?) -> Unit): Unit {
+        val response = catApi(hash)
+        if (response.isSuccessful && null != response.body()) {
+            response.body()!!.use { it.byteStream().use(handler) }
+        } else {
+            handler.invoke(null)
+        }
+    }
+
+    /**
+     * If you cat a wrong hash, the ipfs http api will response code 500
+     * and with message. In this case if we use the response boy and cover it
+     * to stream or byte ,it will not the true content of the hash code,it will
+     * be the content of the 'Wrong Message'.
+     *
+     * So we need check the response code by {response.isSuccessful} to insure
+     * we go the right response.
+     */
+    private fun catApi(hash: String):Response{
+        val request = Request.Builder()
+            .url(ipfs.config.base_url + "cat/$hash")
+            .build()
+        return ipfs.config.okHttpClient.newCall(request).execute()
+    }
 
 }


### PR DESCRIPTION
If you cat a wrong hash, the ipfs http api will response code 500
and with message. In this case if we use the response boy and cover it
to stream or byte ,it will not the true content of the hash code,it will
be the content of the 'Wrong Message'.

So we need check the response code by {response.isSuccessful} to insure
we go the right response.

OKHTTP: <-- 500 Internal Server Error http://127.0.0.1:5001/api/v0/cat/QmZC6gALejeRt2TAHHMnEkcEXeyX3XUSZ4yRkpt43UkM5A?timeout=30s (30002ms)
OKHTTP: Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
OKHTTP: Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
OKHTTP: Content-Type: application/json
OKHTTP: Server: go-ipfs/0.4.18-190117
OKHTTP: Trailer: X-Stream-Error
OKHTTP: Vary: Origin
OKHTTP: Date: Tue, 26 Feb 2019 03:18:31 GMT
OKHTTP: Transfer-Encoding: chunked
OKHTTP: {"Message":"failed to get block for QmZC6gALejeRt2TAHHMnEkcEXeyX3XUSZ4yRkpt43UkM5A: context deadline exceeded","Code":0,"Type":"error"}
OKHTTP: <-- END HTTP (136-byte body)